### PR TITLE
24시간 제한 기반 플러스원 기능 구현 방식 변경

### DIFF
--- a/app/api/click/route.ts
+++ b/app/api/click/route.ts
@@ -1,16 +1,23 @@
+import { ONE_DAY_MS } from "@/constant";
+import { getSession } from "@/lib/session";
 import { supabase } from "@/lib/supabase";
-import { NextRequest, NextResponse } from "next/server";
+import { createNewUser } from "@/lib/create-new-user";
+import { getTimeLeftUntil24Hours } from "@/lib/get-time-left";
+import { buildAPIResponse } from "@/lib/build-response";
+import { NextRequest } from "next/server";
 
-export async function POST(req: NextRequest) {
-  if (req.method !== "POST") {
-    return NextResponse.json(
-      { error: "허용되지 않은 메서드입니다." },
-      { status: 405 }
-    );
+/**
+ * 클릭 이벤트를 처리하는 API 엔드포인트
+ * GET 요청: 클릭 이벤트 기록 및 플러스원 처리
+ */
+export async function GET(req: NextRequest) {
+  if (req.method !== "GET") {
+    return buildAPIResponse({
+      success: false,
+      message: "허용되지 않은 메서드입니다.",
+      status: 405,
+    });
   }
-
-  const body = await req.json();
-  const uuid = body.id;
 
   const forwardedFor = req.headers.get("x-forwarded-for");
   const ip = forwardedFor?.split(",")[0]?.trim() ?? "unknown";
@@ -21,67 +28,76 @@ export async function POST(req: NextRequest) {
 
   // 로컬에서 테스트할 경우 무조건 통과
   if (ip === "::1" || ip === "127.0.0.1") {
-    await supabase.from("click_logs").insert([{ uuid, ip, clicked_at: now }]);
+    await supabase
+      .from("click_logs")
+      .insert([{ ip, clicked_at: now.toISOString() }]);
 
-    return NextResponse.json({
+    return buildAPIResponse({
       success: true,
       message: "플러스원 성공! (로컬 테스트)",
+      status: 200,
     });
   }
 
-  // 기존 클릭 기록 찾기
+  const { id: sessionId } = await getSession();
+
+  // 세션이 없으면 새로 생성
+  if (!sessionId) {
+    return await createNewUser({ ip, now });
+  }
+
+  // 세션이 존재하는 경우엔 기존 클릭 확인
   const { data: existing, error: fetchError } = await supabase
     .from("clicks")
     .select("*")
-    .eq("uuid", uuid)
-    .eq("ip", ip)
-    .limit(1);
+    .eq("id", sessionId)
+    .maybeSingle();
 
   if (fetchError) {
-    return NextResponse.json({ error: fetchError.message }, { status: 500 });
-  }
+    console.error("클릭 기록 조회 중 오류 발생:", fetchError);
 
-  if (existing && existing.length > 0) {
-    const prevClick = new Date(existing[0].clicked_at);
-    const diff = now.getTime() - prevClick.getTime();
-
-    if (diff < 1000 * 60 * 60 * 24) {
-      const msLeft = 1000 * 60 * 60 * 24 - diff;
-      const hoursLeft = Math.floor(msLeft / (1000 * 60 * 60));
-      const minutesLeft = Math.floor((msLeft % (1000 * 60 * 60)) / (1000 * 60));
-      const secondsLeft = Math.floor((msLeft % (1000 * 60)) / 1000);
-
-      return NextResponse.json(
-        {
-          success: false,
-          message: `다음 플러스원까지 ${hoursLeft}시간 ${minutesLeft}분 ${secondsLeft}초 남았어요.`,
-        },
-        { status: 429 }
-      );
-    } else {
-      // 기존 사용자 & 24시간 경과 -> 업데이트
-      await supabase
-        .from("clicks")
-        .update({ clicked_at: now.toISOString() })
-        .eq("uuid", uuid)
-        .eq("ip", ip);
-
-      await supabase.from("click_logs").insert([{ uuid, ip, clicked_at: now }]);
-
-      return NextResponse.json({
-        success: true,
-        message: "플러스원 성공!",
-      });
-    }
-  } else {
-    // 신규 사용자 추가
-    await supabase.from("clicks").insert([{ uuid, ip, clicked_at: now }]);
-    // 클릭 로그 기록
-    await supabase.from("click_logs").insert([{ uuid, ip, clicked_at: now }]);
-
-    return NextResponse.json({
-      success: true,
-      message: "플러스원 성공!",
+    return buildAPIResponse({
+      success: false,
+      message: fetchError?.message,
+      status: 500,
     });
   }
+
+  // 세션은 존재하는데 클릭 기록이 없는 경우 -> 신규 사용자로 추가
+  if (!existing) {
+    return await createNewUser({ ip, now });
+  }
+
+  // 기존 세션이 존재하는 경우
+  const prevClick = new Date(existing.clicked_at);
+  const diff = now.getTime() - prevClick.getTime();
+
+  // 24시간 이내에 다시 클릭한 경우
+  if (diff < ONE_DAY_MS) {
+    const { hoursLeft, minutesLeft, secondsLeft } =
+      getTimeLeftUntil24Hours(diff);
+
+    return buildAPIResponse({
+      success: false,
+      message: `다음 플러스원까지 ${hoursLeft}시간 ${minutesLeft}분 ${secondsLeft}초 남았어요.`,
+      status: 429,
+    });
+  }
+
+  // 기존 사용자 & 24시간 경과 -> 업데이트
+  await supabase
+    .from("clicks")
+    .update({ ip, clicked_at: now.toISOString() })
+    .eq("id", sessionId);
+
+  // 클릭 로그 작성
+  await supabase
+    .from("click_logs")
+    .insert([{ uuid: sessionId, ip, clicked_at: now.toISOString() }]);
+
+  return buildAPIResponse({
+    success: true,
+    message: "플러스원 성공!",
+    status: 200,
+  });
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -13,7 +13,7 @@ const faqLinks = [
 
 export default function Footer() {
   return (
-    <footer className="w-full mx-auto p-5 bg-neutral-50 font-paperlogy">
+    <footer className="w-full mx-auto p-5 bg-neutral-50 dark:bg-neutral-900 font-paperlogy">
       <div className="max-w-screen-sm mx-auto space-y-5">
         <section className="grid grid-cols-4">
           <div>
@@ -23,7 +23,7 @@ export default function Footer() {
                 <li key={href}>
                   <Link
                     href={href}
-                    className="text-neutral-700 hover:text-neutral-500"
+                    className="text-neutral-700 hover:text-neutral-500 dark:text-neutral-400 dark:hover:text-neutral-300"
                   >
                     {label}
                   </Link>
@@ -38,7 +38,7 @@ export default function Footer() {
                 <li key={href}>
                   <Link
                     href={href}
-                    className="text-neutral-700 hover:text-neutral-500"
+                    className="text-neutral-700 hover:text-neutral-500 dark:text-neutral-400 dark:hover:text-neutral-300"
                   >
                     {label}
                   </Link>

--- a/components/plus-btn.tsx
+++ b/components/plus-btn.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import FingerprintJS from "@fingerprintjs/fingerprintjs";
 import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
 
 export default function PlusBtn({ isError = false }: { isError?: boolean }) {
@@ -11,16 +10,11 @@ export default function PlusBtn({ isError = false }: { isError?: boolean }) {
   // reCAPTCHA 훅
   const { executeRecaptcha } = useGoogleReCaptcha();
 
-  // const getFingerprint = async () => {
-  //   const fp = await FingerprintJS.load();
-  //   const result = await fp.get();
-  //   return result.visitorId;
-  // };
-
   const handleClick = async () => {
     if (!executeRecaptcha) {
       return alert("reCAPTCHA 로딩 중입니다...");
     }
+
     setIsLoading(true);
 
     // reCAPTCHA token
@@ -39,9 +33,6 @@ export default function PlusBtn({ isError = false }: { isError?: boolean }) {
         verified.message || "로봇 의심됨. 나중에 다시 시도해 주세요."
       );
     }
-
-    // fingerprint ID
-    // const id = await getFingerprint();
 
     if (!token) {
       return alert("플러스원 실패. 나중에 다시 시도해 주세요.");

--- a/components/plus-btn.tsx
+++ b/components/plus-btn.tsx
@@ -47,6 +47,7 @@ export default function PlusBtn({ isError = false }: { isError?: boolean }) {
       return alert("플러스원 실패. 나중에 다시 시도해 주세요.");
     }
 
+    // 서버에 클릭 이벤트 전송
     const response = await fetch("/api/click", {
       method: "POST",
       headers: {

--- a/components/plus-btn.tsx
+++ b/components/plus-btn.tsx
@@ -11,11 +11,11 @@ export default function PlusBtn({ isError = false }: { isError?: boolean }) {
   // reCAPTCHA 훅
   const { executeRecaptcha } = useGoogleReCaptcha();
 
-  const getFingerprint = async () => {
-    const fp = await FingerprintJS.load();
-    const result = await fp.get();
-    return result.visitorId;
-  };
+  // const getFingerprint = async () => {
+  //   const fp = await FingerprintJS.load();
+  //   const result = await fp.get();
+  //   return result.visitorId;
+  // };
 
   const handleClick = async () => {
     if (!executeRecaptcha) {
@@ -41,19 +41,18 @@ export default function PlusBtn({ isError = false }: { isError?: boolean }) {
     }
 
     // fingerprint ID
-    const id = await getFingerprint();
+    // const id = await getFingerprint();
 
-    if (!id || !token) {
+    if (!token) {
       return alert("플러스원 실패. 나중에 다시 시도해 주세요.");
     }
 
     // 서버에 클릭 이벤트 전송
     const response = await fetch("/api/click", {
-      method: "POST",
+      method: "GET",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ id }),
     });
 
     const data = await response.json();

--- a/constant.ts
+++ b/constant.ts
@@ -1,0 +1,1 @@
+export const ONE_DAY_MS = 1000 * 60 * 60 * 24;

--- a/lib/build-response.ts
+++ b/lib/build-response.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+interface BuildAPIResponseInput {
+  success: boolean;
+  status: number;
+  message?: string;
+}
+
+export function buildAPIResponse({
+  success,
+  status,
+  message,
+}: BuildAPIResponseInput) {
+  return NextResponse.json({ success, message }, { status });
+}

--- a/lib/create-new-user.ts
+++ b/lib/create-new-user.ts
@@ -1,0 +1,59 @@
+import { supabase } from "./supabase";
+import { getSession } from "./session";
+import { buildAPIResponse } from "./build-response";
+import { NextResponse } from "next/server";
+
+interface CreateNewUserProps {
+  ip: string;
+  now: Date;
+}
+
+export async function createNewUser({
+  ip,
+  now,
+}: CreateNewUserProps): Promise<NextResponse> {
+  // 신규 사용자 추가
+  const { data, error } = await supabase
+    .from("clicks")
+    .insert([{ ip, clicked_at: now.toISOString() }])
+    .select("id")
+    .single();
+
+  const uuid = data?.id as string;
+
+  if (!uuid) {
+    console.error("플러스원 생성 실패: UUID가 없습니다.");
+
+    return buildAPIResponse({
+      success: false,
+      message: "플러스원 생성 실패. 나중에 다시 시도해 주세요.",
+      status: 500,
+    });
+  }
+
+  if (error) {
+    console.error("플러스원 생성 중 오류 발생:", error);
+
+    return buildAPIResponse({
+      success: false,
+      message: error?.message,
+      status: 500,
+    });
+  }
+
+  // 클릭 로그 기록
+  await supabase
+    .from("click_logs")
+    .insert([{ uuid, ip, clicked_at: now.toISOString() }]);
+
+  // 세션에 ID 저장
+  const session = await getSession();
+  session.id = uuid;
+  await session.save();
+
+  return buildAPIResponse({
+    success: true,
+    message: "플러스원 성공!",
+    status: 200,
+  });
+}

--- a/lib/get-time-left.ts
+++ b/lib/get-time-left.ts
@@ -1,0 +1,14 @@
+import { ONE_DAY_MS } from "@/constant";
+
+export function getTimeLeftUntil24Hours(diffMs: number) {
+  const msLeft = ONE_DAY_MS - diffMs;
+  const hoursLeft = Math.floor(msLeft / (1000 * 60 * 60));
+  const minutesLeft = Math.floor((msLeft % (1000 * 60 * 60)) / (1000 * 60));
+  const secondsLeft = Math.floor((msLeft % (1000 * 60)) / 1000);
+
+  return {
+    hoursLeft,
+    minutesLeft,
+    secondsLeft,
+  };
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,7 +1,8 @@
-import { SessionOptions } from "iron-session";
+import { getIronSession, SessionOptions } from "iron-session";
+import { cookies } from "next/headers";
 
 export type SessionData = {
-  id: string; // 클릭 시 발급된 고유 ID
+  id?: string; // 클릭 시 발급된 고유 ID
 };
 
 export const sessionOptions: SessionOptions = {
@@ -14,3 +15,9 @@ export const sessionOptions: SessionOptions = {
     maxAge: 60 * 60 * 24, // 24시간
   },
 };
+
+// App Router 전용 session getter
+export async function getSession() {
+  const cookieStore = await cookies();
+  return getIronSession<SessionData>(cookieStore, sessionOptions);
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,16 @@
+import { SessionOptions } from "iron-session";
+
+export type SessionData = {
+  id: string; // 클릭 시 발급된 고유 ID
+};
+
+export const sessionOptions: SessionOptions = {
+  password: process.env.IRON_SESSION_PASSWORD as string,
+  cookieName: "PSO_VSID",
+  cookieOptions: {
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24, // 24시간
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fingerprintjs/fingerprintjs": "^4.6.2",
         "@supabase/supabase-js": "^2.50.3",
         "gsap": "^3.13.0",
+        "iron-session": "^8.0.4",
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -2475,6 +2476,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3775,6 +3785,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/iron-session": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/iron-session/-/iron-session-8.0.4.tgz",
+      "integrity": "sha512-9ivNnaKOd08osD0lJ3i6If23GFS2LsxyMU8Gf/uBUEgm8/8CC1hrrCHFDpMo3IFbpBgwoo/eairRsaD3c5itxA==",
+      "funding": [
+        "https://github.com/sponsors/vvo",
+        "https://github.com/sponsors/brc-dd"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.2",
+        "iron-webcrypto": "^1.2.1",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6120,6 +6154,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "plusone",
       "version": "0.1.0",
       "dependencies": {
-        "@fingerprintjs/fingerprintjs": "^4.6.2",
         "@supabase/supabase-js": "^2.50.3",
         "gsap": "^3.13.0",
         "iron-session": "^8.0.4",
@@ -241,15 +240,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fingerprintjs/fingerprintjs": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs/-/fingerprintjs-4.6.2.tgz",
-      "integrity": "sha512-g8mXuqcFKbgH2CZKwPfVtsUJDHyvcgIABQI7Y0tzWEFXpGxJaXuAuzlifT2oTakjDBLTK4Gaa9/5PERDhqUjtw==",
-      "license": "BUSL-1.1",
-      "dependencies": {
-        "tslib": "^2.4.1"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fingerprintjs/fingerprintjs": "^4.6.2",
     "@supabase/supabase-js": "^2.50.3",
     "gsap": "^3.13.0",
+    "iron-session": "^8.0.4",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@fingerprintjs/fingerprintjs": "^4.6.2",
     "@supabase/supabase-js": "^2.50.3",
     "gsap": "^3.13.0",
     "iron-session": "^8.0.4",


### PR DESCRIPTION
### ✅ 주요 변경 사항

- GET /api/click 엔드포인트 구현
- 사용자의 IP와 세션 기반으로 클릭 여부 확인
- 신규 사용자일 경우 자동으로 UUID 발급 및 세션 저장
- supabase.clicks(id) / click_logs(uuid) 테이블 연동
- 클릭 기록은 click_logs 테이블에 개별 기록으로 저장
- createNewUser() 등 책임 분리된 유틸 함수 도입
- getTimeLeftUntil24Hours() 유틸 함수로 남은 시간 계산
- ON DELETE SET NULL 옵션을 고려한 FK 및 nullable 설정 반영
- 응답 포맷 통일화를 위한 buildResponse() 유틸 도입

---

### 🧪 테스트 방법
1. /api/click에 GET 요청
2. 처음 요청 시 “플러스원 성공!” 메시지 확인
3. 재요청 시 24시간 남은 시간 안내 메시지 확인
4. Supabase DB에서 clicks, click_logs 테이블에 데이터 저장 여부 확인
5. 로컬 IP(::1, 127.0.0.1)로 요청 시 강제 성공 테스트

---

### 💬 기타 참고사항
- uuid 외래키는 삭제 시 null 처리되도록 설정
- 세션은 iron-session 기반, 24시간 유지

---