### PR TITLE
스트릭(잔디) 연도별 정렬 기능 추가

### DIFF
--- a/app/(main)/loading.tsx
+++ b/app/(main)/loading.tsx
@@ -1,0 +1,24 @@
+export default function Loading() {
+  return null;
+}
+
+export function CalendarLoading() {
+  return (
+    <section
+      className="w-full max-w-screen-xl mx-auto sm:p-5 p-3 relative border rounded-lg
+      border-neutral-50 dark:border-neutral-900 dark:bg-neutral-900 shadow"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-start font-medium text-lg flex items-center gap-1">
+          <div className="size-5 bg-neutral-400 animate-pulse rounded-full" />
+          <div className="w-20 h-3 bg-neutral-400 animate-pulse rounded-full" />
+        </div>
+        <div className="w-16 h-5 bg-neutral-400 animate-pulse rounded" />
+      </div>
+      <div className="mt-5 w-full h-[192px] bg-neutral-400 animate-pulse rounded" />
+      <div className="flex justify-end">
+        <div className="w-24 h-3 mt-4 bg-neutral-400 animate-pulse rounded" />
+      </div>
+    </section>
+  );
+}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -4,6 +4,7 @@ import GoogleCaptcha from "@/components/recaptcha-wrapper";
 import View from "@/components/view";
 import Image from "next/image";
 import { Suspense } from "react";
+import { CalendarLoading } from "./loading";
 
 export default function Home() {
   return (
@@ -25,13 +26,7 @@ export default function Home() {
           </div>
           <View />
         </section>
-        <Suspense
-          fallback={
-            <div className="py-12">
-              <Loader />
-            </div>
-          }
-        >
+        <Suspense fallback={<CalendarLoading />}>
           <ActivityCalendarController />
         </Suspense>
       </main>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,13 +1,15 @@
 import ActivityCalendarController from "@/components/activity-calendar/controller";
+import Loader from "@/components/loader";
 import GoogleCaptcha from "@/components/recaptcha-wrapper";
 import View from "@/components/view";
 import Image from "next/image";
+import { Suspense } from "react";
 
 export default function Home() {
   return (
     <GoogleCaptcha>
       <main className="font-paperlogy py-12 space-y-12">
-        <section className="w-full max-w-screen-sm mx-auto p-5 space-y-3 text-center">
+        <section className="w-full max-w-screen-xl mx-auto p-5 space-y-3 text-center">
           <div>
             <Image
               src="/plusone.webp"
@@ -23,7 +25,15 @@ export default function Home() {
           </div>
           <View />
         </section>
-        <ActivityCalendarController />
+        <Suspense
+          fallback={
+            <div className="py-12">
+              <Loader />
+            </div>
+          }
+        >
+          <ActivityCalendarController />
+        </Suspense>
       </main>
     </GoogleCaptcha>
   );

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,5 +1,4 @@
 import ActivityCalendarController from "@/components/activity-calendar/controller";
-import Loader from "@/components/loader";
 import GoogleCaptcha from "@/components/recaptcha-wrapper";
 import View from "@/components/view";
 import Image from "next/image";

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
 
 export default function ContactPage() {
   return (
-    <main className="max-w-screen-sm mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy">
+    <main className="max-w-screen-xl mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy">
       <h1 className="text-2xl font-bold mb-4">문의하기</h1>
       <Link
         href="/"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
 
 export default function ContactPage() {
   return (
-    <main className="max-w-screen-xl mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy">
+    <main className="max-w-screen-xl mx-auto py-12 px-5 text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy">
       <h1 className="text-2xl font-bold mb-4">문의하기</h1>
       <Link
         href="/"

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
 
 export default function PrivacyPolicyPage() {
   return (
-    <main className="max-w-screen-sm mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy min-h-screen">
+    <main className="max-w-screen-xl mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy min-h-screen">
       <h1 className="text-2xl font-bold mb-4">개인정보 처리방침</h1>
       <p className="text-xs text-neutral-500 mb-2">시행일자: 2025년 7월 7일</p>
       <Link

--- a/app/tos/page.tsx
+++ b/app/tos/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
 
 export default function TermsOfServicePage() {
   return (
-    <main className="max-w-screen-sm mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy min-h-screen">
+    <main className="max-w-screen-xl mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy min-h-screen">
       <h1 className="text-3xl font-bold mb-6">이용약관</h1>
       <p className="text-xs text-neutral-500 mb-4">시행일자: 2025년 7월 7일</p>
 

--- a/app/update/add/page.tsx
+++ b/app/update/add/page.tsx
@@ -7,7 +7,7 @@ export default async function AddUpdatePage() {
   if (!isDev) return redirect("/");
 
   return (
-    <main className="max-w-screen-sm min-h-screen mx-auto py-12 px-5 font-paperlogy">
+    <main className="max-w-screen-xl min-h-screen mx-auto py-12 px-5 font-paperlogy">
       <h1 className="text-xl font-semibold mb-4">업데이트 추가</h1>
       <UpdateForm />
     </main>

--- a/app/update/page.tsx
+++ b/app/update/page.tsx
@@ -13,7 +13,7 @@ export default async function UpdatePage() {
   const updates = await getUpdates();
 
   return (
-    <main className="max-w-screen-sm h-screen overflow-scroll mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy">
+    <main className="max-w-screen-sm min-h-screen mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy">
       <h1 className="text-2xl font-bold mb-4">업데이트 내역</h1>
       <Link
         href="/"

--- a/app/update/page.tsx
+++ b/app/update/page.tsx
@@ -13,7 +13,7 @@ export default async function UpdatePage() {
   const updates = await getUpdates();
 
   return (
-    <main className="max-w-screen-sm min-h-screen mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy">
+    <main className="max-w-screen-xl min-h-screen mx-auto py-12 px-5 text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed font-paperlogy">
       <h1 className="text-2xl font-bold mb-4">업데이트 내역</h1>
       <Link
         href="/"

--- a/components/activity-calendar/block-tooltip.tsx
+++ b/components/activity-calendar/block-tooltip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { Activity, BlockElement } from "react-activity-calendar";
 

--- a/components/activity-calendar/controller.tsx
+++ b/components/activity-calendar/controller.tsx
@@ -3,6 +3,7 @@ import { getActivity } from "@/app/(main)/actions";
 import ActivityCalendarView from "./view";
 
 export default async function ActivityCalendarController() {
+  await new Promise((r) => setTimeout(r, 3000));
   const session = await getSession();
   const { success, data } = await getActivity(session.id);
 

--- a/components/activity-calendar/controller.tsx
+++ b/components/activity-calendar/controller.tsx
@@ -3,7 +3,6 @@ import { getActivity } from "@/app/(main)/actions";
 import ActivityCalendarView from "./view";
 
 export default async function ActivityCalendarController() {
-  await new Promise((r) => setTimeout(r, 3000));
   const session = await getSession();
   const { success, data } = await getActivity(session.id);
 

--- a/components/activity-calendar/controller.tsx
+++ b/components/activity-calendar/controller.tsx
@@ -6,9 +6,5 @@ export default async function ActivityCalendarController() {
   const session = await getSession();
   const { success, data } = await getActivity(session.id);
 
-  return (
-    <div className="p-5">
-      <ActivityCalendarView success={success} {...data} />
-    </div>
-  );
+  return <ActivityCalendarView success={success} {...data} />;
 }

--- a/components/activity-calendar/controller.tsx
+++ b/components/activity-calendar/controller.tsx
@@ -6,5 +6,9 @@ export default async function ActivityCalendarController() {
   const session = await getSession();
   const { success, data } = await getActivity(session.id);
 
-  return <ActivityCalendarView success={success} {...data} />;
+  return (
+    <div className="p-5">
+      <ActivityCalendarView success={success} {...data} />
+    </div>
+  );
 }

--- a/components/activity-calendar/dropdown-sort-selector.tsx
+++ b/components/activity-calendar/dropdown-sort-selector.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { AdjustmentsHorizontalIcon } from "@heroicons/react/24/solid";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import gsap from "gsap";
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface DropdownSelectorProps {
+  options: Option[];
+  selected: Option;
+  onSelect: (option: Option) => void;
+}
+
+export default function DropdownSelector({
+  options,
+  selected,
+  onSelect,
+}: DropdownSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
+
+  const handleSelect = (option: Option) => {
+    onSelect(option);
+    setOpen(false);
+  };
+
+  // 외부 클릭 감지
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open]);
+
+  // GSAP 애니메이션
+  useLayoutEffect(() => {
+    if (!dropdownRef.current) return;
+
+    const el = dropdownRef.current;
+
+    if (open) {
+      gsap.fromTo(
+        el,
+        { opacity: 0, y: -5, display: "none" },
+        {
+          opacity: 1,
+          y: 0,
+          display: "block",
+          duration: 0.2,
+          ease: "power2.out",
+        }
+      );
+    } else {
+      gsap.to(el, {
+        opacity: 0,
+        y: -5,
+        duration: 0.15,
+        ease: "power2.in",
+        onComplete: () => {
+          if (el) el.style.display = "none";
+        },
+      });
+    }
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative text-sm">
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className="px-3 py-1 rounded border bg-white text-neutral-800 border-neutral-300 flex gap-1 items-center
+        dark:bg-neutral-800 dark:text-white dark:border-neutral-700 cursor-pointer"
+      >
+        <AdjustmentsHorizontalIcon className="size-3" /> {selected.label}
+      </button>
+
+      {/* 드롭다운 */}
+      <ul
+        ref={dropdownRef}
+        className="absolute right-0 mt-1 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded shadow z-10 min-w-[100px]"
+        style={{ display: "none", opacity: 0 }}
+      >
+        {options.map((option) => (
+          <li
+            key={option.value}
+            onClick={() => handleSelect(option)}
+            className={`px-3 py-1 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900 ${
+              selected.value === option.value && "font-semibold text-blue-500"
+            }`}
+          >
+            {option.label}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/activity-calendar/dropdown-sort-selector.tsx
+++ b/components/activity-calendar/dropdown-sort-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AdjustmentsHorizontalIcon } from "@heroicons/react/24/solid";
+import { FunnelIcon } from "@heroicons/react/24/outline";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import gsap from "gsap";
 
@@ -87,7 +87,7 @@ export default function DropdownSelector({
         className="px-3 py-1 rounded border bg-white text-neutral-800 border-neutral-300 flex gap-1 items-center
         dark:bg-neutral-800 dark:text-white dark:border-neutral-700 cursor-pointer"
       >
-        <AdjustmentsHorizontalIcon className="size-3" /> {selected.label}
+        <FunnelIcon className="size-3" /> {selected.label}
       </button>
 
       {/* 드롭다운 */}

--- a/components/activity-calendar/view.tsx
+++ b/components/activity-calendar/view.tsx
@@ -47,14 +47,14 @@ export default function ActivityCalendarView({
 
   return (
     <section
-      className="w-full max-w-screen-sm mx-auto p-5 relative border rounded-lg
+      className="w-full max-w-screen-sm mx-auto sm:p-5 p-3 relative border rounded-lg
       border-neutral-50 dark:border-neutral-900 dark:bg-neutral-900 shadow"
     >
       <p className="text-start font-medium flex items-center gap-1">
         <RectangleGroupIcon className="size-4 text-blue-500 " />
         <span>스트릭</span>
       </p>
-      <div style={{ direction: "rtl" }} className="mt-5">
+      <div style={{ direction: "rtl" }} className="mt-3">
         <ActivityCalendar
           data={activity}
           blockMargin={5}

--- a/components/activity-calendar/view.tsx
+++ b/components/activity-calendar/view.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import { ActivityData } from "@/lib/generate-past-year-data";
+import { useActivityFilter } from "@/lib/hooks/use-activity-filter";
+import CustomToast from "../custom-toast";
+import CalendarBlockTooltip from "./block-tooltip";
+import DropdownSelector from "./dropdown-sort-selector";
 import {
   ActivityCalendar,
   Props as CalendarProps,
   ThemeInput,
 } from "react-activity-calendar";
-import { ActivityData } from "@/lib/generate-past-year-data";
-import { toast } from "sonner";
-import CustomToast from "../custom-toast";
-import CalendarBlockTooltip from "./block-tooltip";
 import { RectangleGroupIcon } from "@heroicons/react/24/solid";
+import { toast } from "sonner";
+import { useEffect } from "react";
 
 const theme: ThemeInput = {
   light: ["#f0f0f0", "#3B82F6"],
@@ -34,7 +36,9 @@ export default function ActivityCalendarView({
   activity: initialActivity,
   count,
 }: ActivityCalendarViewProps) {
-  const [activity, setActivity] = useState(initialActivity);
+  const { activity, selected, sortOptions, handleChange } = useActivityFilter({
+    initialActivity,
+  });
 
   useEffect(() => {
     if (!success) {
@@ -49,14 +53,21 @@ export default function ActivityCalendarView({
 
   return (
     <section
-      className="w-full max-w-screen-sm mx-auto sm:p-5 p-3 relative border rounded-lg
+      className="w-full max-w-screen-xl mx-auto sm:p-5 p-3 relative border rounded-lg
       border-neutral-50 dark:border-neutral-900 dark:bg-neutral-900 shadow"
     >
-      <p className="text-start font-medium flex items-center gap-1">
-        <RectangleGroupIcon className="size-4 text-blue-500 " />
-        <span>스트릭</span>
-      </p>
-      <div style={{ direction: "rtl" }} className="mt-3">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-start font-medium text-lg flex items-center gap-1">
+          <RectangleGroupIcon className="size-5 text-blue-500" />
+          <span>스트릭</span>
+        </p>
+        <DropdownSelector
+          options={sortOptions}
+          selected={selected}
+          onSelect={handleChange}
+        />
+      </div>
+      <div style={{ direction: "rtl" }} className="mt-5 flex justify-center">
         <ActivityCalendar
           data={activity}
           blockMargin={5}

--- a/components/activity-calendar/view.tsx
+++ b/components/activity-calendar/view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import {
   ActivityCalendar,
   Props as CalendarProps,
@@ -12,7 +12,7 @@ import CustomToast from "../custom-toast";
 import CalendarBlockTooltip from "./block-tooltip";
 import { RectangleGroupIcon } from "@heroicons/react/24/solid";
 
-const explicitTheme: ThemeInput = {
+const theme: ThemeInput = {
   light: ["#f0f0f0", "#3B82F6"],
   dark: ["#262626", "#3B82F6"],
 };
@@ -31,9 +31,11 @@ interface ActivityCalendarViewProps {
 
 export default function ActivityCalendarView({
   success,
-  activity,
+  activity: initialActivity,
   count,
 }: ActivityCalendarViewProps) {
+  const [activity, setActivity] = useState(initialActivity);
+
   useEffect(() => {
     if (!success) {
       toast(
@@ -62,11 +64,11 @@ export default function ActivityCalendarView({
           blockSize={20}
           maxLevel={1}
           hideColorLegend
-          labels={labels}
           totalCount={count}
           fontSize={14}
           weekStart={1}
-          theme={explicitTheme}
+          labels={labels}
+          theme={theme}
           renderBlock={(block, activity) => (
             <CalendarBlockTooltip activity={activity}>
               {block}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 
 const infoLinks = [
@@ -15,21 +14,8 @@ const faqLinks = [
 export default function Footer() {
   return (
     <footer className="w-full p-5 bg-neutral-50 dark:bg-neutral-900 font-paperlogy space-y-5">
-      <section className="flex gap-10">
-        <Link href="/">
-          <div className="text-center">
-            <Image
-              src="/plusone.webp"
-              alt="플러스원! 로고"
-              width={50}
-              height={50}
-              priority
-              className="mx-auto"
-            />
-            <p className="font-semibold text-lg">플러스원!</p>
-          </div>
-        </Link>
-        <div className="grid grid-cols-3 gap-3">
+      <div className="max-w-screen-sm mx-auto">
+        <section className="grid grid-cols-3 gap-3">
           <div>
             <p className="font-semibold text-lg">정보</p>
             <ul className="flex flex-col gap-1 mt-2">
@@ -60,42 +46,42 @@ export default function Footer() {
               ))}
             </ul>
           </div>
-        </div>
-      </section>
-      <section className="mt-4 space-y-2 sm:text-end">
-        <p className="text-xs text-neutral-400">
-          © 2025{" "}
-          <Link
-            href="https://github.com/pvvng"
-            target="_blank"
-            className="text-blue-500 hover:text-blue-600 underline"
-          >
-            pvvng
-          </Link>
-          . 모든 권리 보유.
-        </p>
-        <p className="text-xs text-neutral-400">
-          이 사이트는 reCAPTCHA의 보호를 받으며, Google{" "}
-          <Link
-            href="https://policies.google.com/privacy"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline text-blue-500 hover:text-blue-600"
-          >
-            개인정보처리방침
-          </Link>{" "}
-          및{" "}
-          <Link
-            href="https://policies.google.com/terms"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline text-blue-500 hover:text-blue-600"
-          >
-            서비스 약관
-          </Link>
-          이 적용됩니다.
-        </p>
-      </section>
+        </section>
+        <section className="mt-4 space-y-2 sm:text-end">
+          <p className="text-xs text-neutral-400">
+            © 2025{" "}
+            <Link
+              href="https://github.com/pvvng"
+              target="_blank"
+              className="text-blue-500 hover:text-blue-600 underline"
+            >
+              pvvng
+            </Link>
+            . 모든 권리 보유.
+          </p>
+          <p className="text-xs text-neutral-400">
+            이 사이트는 reCAPTCHA의 보호를 받으며, Google{" "}
+            <Link
+              href="https://policies.google.com/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-blue-500 hover:text-blue-600"
+            >
+              개인정보처리방침
+            </Link>{" "}
+            및{" "}
+            <Link
+              href="https://policies.google.com/terms"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-blue-500 hover:text-blue-600"
+            >
+              서비스 약관
+            </Link>
+            이 적용됩니다.
+          </p>
+        </section>
+      </div>
     </footer>
   );
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -14,74 +14,72 @@ const faqLinks = [
 export default function Footer() {
   return (
     <footer className="w-full p-5 bg-neutral-50 dark:bg-neutral-900 font-paperlogy space-y-5">
-      <div className="max-w-screen-sm mx-auto">
-        <section className="grid grid-cols-3 gap-3">
-          <div>
-            <p className="font-semibold text-lg">정보</p>
-            <ul className="flex flex-col gap-1 mt-2">
-              {infoLinks.map(({ href, label }) => (
-                <li key={href}>
-                  <Link
-                    href={href}
-                    className="text-neutral-700 hover:text-neutral-500 dark:text-neutral-400 dark:hover:text-neutral-300"
-                  >
-                    {label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <p className="font-semibold text-lg">문의</p>
-            <ul className="flex flex-col gap-1 mt-2">
-              {faqLinks.map(({ href, label }) => (
-                <li key={href}>
-                  <Link
-                    href={href}
-                    className="text-neutral-700 hover:text-neutral-500 dark:text-neutral-400 dark:hover:text-neutral-300"
-                  >
-                    {label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-        <section className="mt-4 space-y-2 sm:text-end">
-          <p className="text-xs text-neutral-400">
-            © 2025{" "}
-            <Link
-              href="https://github.com/pvvng"
-              target="_blank"
-              className="text-blue-500 hover:text-blue-600 underline"
-            >
-              pvvng
-            </Link>
-            . 모든 권리 보유.
-          </p>
-          <p className="text-xs text-neutral-400">
-            이 사이트는 reCAPTCHA의 보호를 받으며, Google{" "}
-            <Link
-              href="https://policies.google.com/privacy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline text-blue-500 hover:text-blue-600"
-            >
-              개인정보처리방침
-            </Link>{" "}
-            및{" "}
-            <Link
-              href="https://policies.google.com/terms"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline text-blue-500 hover:text-blue-600"
-            >
-              서비스 약관
-            </Link>
-            이 적용됩니다.
-          </p>
-        </section>
-      </div>
+      <section className="max-w-screen-xl mx-auto flex gap-5">
+        <div>
+          <p className="font-semibold text-lg">정보</p>
+          <ul className="flex flex-col gap-1 mt-2">
+            {infoLinks.map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="text-neutral-700 hover:text-neutral-500 dark:text-neutral-400 dark:hover:text-neutral-300"
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="font-semibold text-lg">문의</p>
+          <ul className="flex flex-col gap-1 mt-2">
+            {faqLinks.map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="text-neutral-700 hover:text-neutral-500 dark:text-neutral-400 dark:hover:text-neutral-300"
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+      <section className="mt-4 space-y-2 sm:text-end">
+        <p className="text-xs text-neutral-400">
+          © 2025{" "}
+          <Link
+            href="https://github.com/pvvng"
+            target="_blank"
+            className="text-blue-500 hover:text-blue-600 underline"
+          >
+            pvvng
+          </Link>
+          . 모든 권리 보유.
+        </p>
+        <p className="text-xs text-neutral-400">
+          이 사이트는 reCAPTCHA의 보호를 받으며, Google{" "}
+          <Link
+            href="https://policies.google.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-blue-500 hover:text-blue-600"
+          >
+            개인정보처리방침
+          </Link>{" "}
+          및{" "}
+          <Link
+            href="https://policies.google.com/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-blue-500 hover:text-blue-600"
+          >
+            서비스 약관
+          </Link>
+          이 적용됩니다.
+        </p>
+      </section>
     </footer>
   );
 }

--- a/lib/hooks/use-activity-filter.tsx
+++ b/lib/hooks/use-activity-filter.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import {
+  ActivityData,
+  generatePastYearData,
+} from "@/lib/generate-past-year-data";
+import { getKoreanDate } from "@/lib/get-korean-date";
+
+interface SortOption {
+  label: string;
+  value: string;
+}
+
+export function useActivityFilter({
+  initialActivity,
+}: {
+  initialActivity: ActivityData[];
+}) {
+  const thisYear = new Date().getFullYear();
+  const lastYear = thisYear - 1;
+
+  const sortOptions: SortOption[] = [
+    { label: "기본", value: getKoreanDate().split("T")[0] },
+    { label: `${lastYear}년`, value: `${lastYear}-12-31` },
+    { label: `${thisYear}년`, value: `${thisYear}-12-31` },
+  ];
+
+  const [selected, setSelected] = useState(sortOptions[0]);
+  const [activity, setActivity] = useState(initialActivity);
+
+  const handleChange = (option: SortOption) => {
+    setSelected(option);
+    const baseData = generatePastYearData(option.value);
+
+    const activeDates = new Set(
+      initialActivity.filter((a) => a.count > 0).map((a) => a.date)
+    );
+
+    const merged = baseData.map((entry) =>
+      activeDates.has(entry.date) ? { ...entry, count: 1, level: 1 } : entry
+    );
+
+    setActivity(merged);
+  };
+
+  return {
+    activity,
+    selected,
+    sortOptions,
+    handleChange,
+  };
+}


### PR DESCRIPTION
## Summary

- ActivityCalendar 컴포넌트에 연도 기준 스트릭 정렬 기능을 추가했습니다.
- 사용자가 "기본 (현재 날짜 기준)", "올해", "작년" 중 하나를 선택해 기준일을 변경할 수 있습니다.
- 선택된 연도 기준으로 1년 치 스트릭 데이터(ActivityData[])를 재구성하고 기존 클릭 데이터는 유지됩니다.

## Changes

- DropdownSelector 컴포넌트 추가: 기본적인 정렬 옵션 UI 구현
- useActivityFilter 커스텀 훅 추가:
  - 초기 스트릭 데이터를 기반으로 연도별 기준일 선택 시 병합 처리
  - generatePastYearData(baseDate)와 클릭된 날짜를 기준으로 merge
- ActivityCalendarView 리팩토링:
  - 정렬 관련 로직 분리
  - View는 selected, options, onSelect만 받고 표시